### PR TITLE
Jsk/save settings

### DIFF
--- a/PluginEditor.h
+++ b/PluginEditor.h
@@ -5,9 +5,11 @@
 
 //==============================================================================
 class AudioPluginAudioProcessorEditor : public juce::AudioProcessorEditor,
-                                        private juce::Slider::Listener, juce::OpenGLContext {
+                                        private juce::Slider::Listener,
+                                        juce::OpenGLContext {
 public:
-  explicit AudioPluginAudioProcessorEditor(AudioPluginAudioProcessor &);
+  explicit AudioPluginAudioProcessorEditor(
+      AudioPluginAudioProcessor &, juce::AudioProcessorValueTreeState &vts);
   ~AudioPluginAudioProcessorEditor() override;
   void updateToggleState(juce::Button *button, juce::String name);
 
@@ -15,46 +17,56 @@ public:
   void paint(juce::Graphics &) override;
   void resized() override;
 
- 
-
-  
   juce::TextEditor equationInput;
 
-  
-
 private:
+  juce::AudioProcessorValueTreeState &valueTreeState;
   void sliderValueChanged(juce::Slider *slider) override;
+
+  typedef juce::AudioProcessorValueTreeState::SliderAttachment SliderAttachment;
+  typedef juce::AudioProcessorValueTreeState::ButtonAttachment ButtonAttachment;
 
   juce::Label OptionLabel{{}, "Option"};
   juce::ToggleButton SquareClippingButton{"Normal 'Square' Clipping"},
-      SawToothClippingButton{"SawTooth Clipping"},noClippingButton{"Disable Clipping"};
+      SawToothClippingButton{"SawTooth Clipping"},
+      noClippingButton{"Disable Clipping"};
 
-  juce::ToggleButton tripleExponentialSmoothingButton{"Triple Exponential Class"};
+  juce::ToggleButton tripleExponentialSmoothingButton{
+      "Triple Exponential Class"};
 
-  juce::ToggleButton customDistortionEquationButton{"Custom Distortion Equation"},noDistortionButton{"Disable Distortion"};
+  juce::ToggleButton customDistortionEquationButton{
+      "Custom Distortion Equation"},
+      noDistortionButton{"Disable Distortion"};
 
   juce::Label gainSliderLabel{"Gain"};
+  juce::Label postGainSliderLabel{"Post Gain"};
   juce::Label clipSliderLabel{"Clip Value"};
   juce::Label sawtoothIncrementSliderLabel;
 
   juce::Label distortionLabel;
   juce::Label clipLabel;
 
-  
-
-
-
-
   void onReturnPressed(juce::TextEditor *textEditor);
 
   AudioPluginAudioProcessor &audioProcessor;
 
-  juce::Slider gainSlider; 
-
+  juce::Slider gainSlider;
+  juce::Slider postGainSlider;
   juce::Slider clipSlider;
-
   juce::Slider sawToothIncrementSlider;
+
+  std::unique_ptr<SliderAttachment> preGainAttachment;
+  std::unique_ptr<SliderAttachment> postGainAttachment;
+  std::unique_ptr<SliderAttachment> clipAttachment;
+
+  std::unique_ptr<ButtonAttachment> noDistortionAttachment;
+  std::unique_ptr<ButtonAttachment> tripleExponentialAttachment;
+  std::unique_ptr<ButtonAttachment> customDistortionEquationAttachment;
+
+  std::unique_ptr<ButtonAttachment> squareClippingAttachment;
+  std::unique_ptr<ButtonAttachment> sawToothClippingAttachment;
+  std::unique_ptr<ButtonAttachment> noClippingAttachment;
+
 
   JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(AudioPluginAudioProcessorEditor)
 };
-

--- a/PluginProcessor.cpp
+++ b/PluginProcessor.cpp
@@ -179,39 +179,35 @@ void AudioPluginAudioProcessor::processBlock(juce::AudioBuffer<float> &buffer,
   // the samples and the outer loop is handling the channels.
   // Alternatively, you can process the samples with the channels
   // interleaved by keeping the same state.
+
+  distortionEquationParser.SetExpr(currentDistortionEquation);
+  distortionEquationParser.DefineVar("x", &varX);
+  distortionEquationParser.DefineVar("e", &eulersNumber);
+  distortionEquationParser.DefineVar("pi", &pi);
+
   for (int channel = 0; channel < totalNumInputChannels; ++channel) {
 
     auto *channelData = buffer.getWritePointer(channel);
 
     try {
-      double eulersNumber = 2.71828;
-      double pi = 3.14159;
-      double varX;
-
-      mu::Parser distortionEquationParser;
-      distortionEquationParser.SetExpr(currentDistortionEquation);
-      distortionEquationParser.DefineVar("x", &varX);
-      distortionEquationParser.DefineVar("e", &eulersNumber);
-      distortionEquationParser.DefineVar("pi", &pi);
-
-      // This may cause lots of overhead,
-      // preGain = preGainParameter->load();
-      //  postGain = postGainParameter->load();
-      //  clipThreshold = clipParameter->load();
 
       clipThreshold = *clipParameter;
       preGain = *preGainParameter;
       postGain = *postGainParameter;
+
+      // For Some reason we can only get parameters back as floats, so to use
+      // them as booleans we determine if they are 1 or 0
 
       enableSquareClipping = *squareClippingParameter < 1 ? false : true;
       enableSawToothClipping = *sawToothClippingParameter < 1 ? false : true;
 
       enableTripleExponentialDistortion =
           *tripleExponentialParameter < 1 ? false : true;
-      enableCustomDistortionEquation = *customDistortionParameter < 1 ? false : true;
+      enableCustomDistortionEquation =
+          *customDistortionParameter < 1 ? false : true;
 
-      // For Some reason we can only get parameters back as floats, so to use
-      // them as booleans we determine if they are 1 or 0
+      if (enableCustomDistortionEquation) {
+      }
 
       for (int sample = 0; sample < buffer.getNumSamples(); sample++) {
 

--- a/PluginProcessor.h
+++ b/PluginProcessor.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <juce_audio_processors/juce_audio_processors.h>
+#include "modules/muparser/include/muParser.h"
 
 //==============================================================================
 class AudioPluginAudioProcessor : public juce::AudioProcessor {
@@ -38,6 +39,12 @@ public:
   bool noDistortion = true;
   bool enableTripleExponentialDistortion = false;
   bool enableCustomDistortionEquation = false;
+
+  double eulersNumber = 2.71828;
+  double pi = 3.14159;
+  double varX;
+  mu::Parser distortionEquationParser;
+
 
   float currentSawToothStep = 0.0f;
 

--- a/PluginProcessor.h
+++ b/PluginProcessor.h
@@ -3,70 +3,78 @@
 #include <juce_audio_processors/juce_audio_processors.h>
 
 //==============================================================================
-class AudioPluginAudioProcessor  : public juce::AudioProcessor
-{
+class AudioPluginAudioProcessor : public juce::AudioProcessor {
 public:
-
-
-
-
-
-
   std::string currentDistortionEquation = "2*x";
 
   float noteOnVel;
-    //==============================================================================
-    AudioPluginAudioProcessor();
-    ~AudioPluginAudioProcessor() override;
+  //==============================================================================
+  AudioPluginAudioProcessor();
+  ~AudioPluginAudioProcessor() override;
 
-    //==============================================================================
-    void prepareToPlay (double sampleRate, int samplesPerBlock) override;
-    void releaseResources() override;
-    juce::Random random;
+  //==============================================================================
+  void prepareToPlay(double sampleRate, int samplesPerBlock) override;
+  void releaseResources() override;
+  juce::Random random;
 
-    double rawVolume;
-    double clipThreshold;
-    bool enableSquareClipping = false;
-    bool enableSawToothClipping = false;
-    bool enableTripleExponentialDistortion = false;
-    bool enableCustomDistortionEquation = false;
+  std::atomic<float> *preGainParameter = nullptr;
+  std::atomic<float> *postGainParameter = nullptr;
+  std::atomic<float> *clipParameter = nullptr;
 
+  std::atomic<float> *noClippingParameter = nullptr;
+  std::atomic<float> *squareClippingParameter = nullptr;
+  std::atomic<float> *sawToothClippingParameter = nullptr;
 
-    float currentSawToothStep = 0.0f;
+  std::atomic<float> *noDistortionParameter = nullptr;
+  std::atomic<float> *tripleExponentialParameter = nullptr;
+  std::atomic<float> *customDistortionParameter = nullptr;
 
-    float currentSawToothStepIncrement = 0.001f;
+  double preGain;
+  double postGain;
+  double clipThreshold;
+  bool noClipping = true;
+  bool enableSquareClipping = false;
+  bool enableSawToothClipping = false;
+  bool noDistortion = true;
+  bool enableTripleExponentialDistortion = false;
+  bool enableCustomDistortionEquation = false;
 
-    void getNextAudioBlock(const juce::AudioSourceChannelInfo &bufferToFill);
+  float currentSawToothStep = 0.0f;
 
-    bool isBusesLayoutSupported (const BusesLayout& layouts) const override;
+  float currentSawToothStepIncrement = 0.001f;
 
-    void processBlock (juce::AudioBuffer<float>&, juce::MidiBuffer&) override;
-    using AudioProcessor::processBlock;
+  void getNextAudioBlock(const juce::AudioSourceChannelInfo &bufferToFill);
 
-    //==============================================================================
-    juce::AudioProcessorEditor* createEditor() override;
-    bool hasEditor() const override;
+  bool isBusesLayoutSupported(const BusesLayout &layouts) const override;
 
-    //==============================================================================
-    const juce::String getName() const override;
+  void processBlock(juce::AudioBuffer<float> &, juce::MidiBuffer &) override;
+  using AudioProcessor::processBlock;
 
-    bool acceptsMidi() const override;
-    bool producesMidi() const override;
-    bool isMidiEffect() const override;
-    double getTailLengthSeconds() const override;
+  //==============================================================================
+  juce::AudioProcessorEditor *createEditor() override;
+  bool hasEditor() const override;
 
-    //==============================================================================
-    int getNumPrograms() override;
-    int getCurrentProgram() override;
-    void setCurrentProgram (int index) override;
-    const juce::String getProgramName (int index) override;
-    void changeProgramName (int index, const juce::String& newName) override;
+  //==============================================================================
+  const juce::String getName() const override;
 
-    //==============================================================================
-    void getStateInformation (juce::MemoryBlock& destData) override;
-    void setStateInformation (const void* data, int sizeInBytes) override;
+  bool acceptsMidi() const override;
+  bool producesMidi() const override;
+  bool isMidiEffect() const override;
+  double getTailLengthSeconds() const override;
+
+  //==============================================================================
+  int getNumPrograms() override;
+  int getCurrentProgram() override;
+  void setCurrentProgram(int index) override;
+  const juce::String getProgramName(int index) override;
+  void changeProgramName(int index, const juce::String &newName) override;
+
+  //==============================================================================
+  void getStateInformation(juce::MemoryBlock &destData) override;
+  void setStateInformation(const void *data, int sizeInBytes) override;
 
 private:
-    //==============================================================================
-    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (AudioPluginAudioProcessor)
+  juce::AudioProcessorValueTreeState parameters;
+  //==============================================================================
+  JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(AudioPluginAudioProcessor)
 };


### PR DESCRIPTION
In order to save settings for the plugin, juce recommends you use the built in audio parameter values instead, so I refactored the code so it now saves the settings in xml.